### PR TITLE
no case sensitive.

### DIFF
--- a/extension.ts
+++ b/extension.ts
@@ -229,7 +229,7 @@ const projectMatchesAllTerms = (
   terms: ReadonlyArray<string>
 ): boolean =>
   terms.every(
-    (term) => project.name.includes(term) || project.path.includes(term)
+      (term) => project.name.toLowerCase().includes(term.toLowerCase()) || project.path.toLowerCase().includes(term.toLowerCase())
   );
 
 /**


### PR DESCRIPTION
## Issue

If you have the project called "Awesome"

You cannot search for it with:
* "AWESOME"
* "awesome"
* "AwEsoMe
* etc

## Solution 

LowerCase applies to all search terms.
