### PR TITLE
Add Android Studio installed from the Toolbox

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,14 +8,14 @@ A Gnome shell extension to add recent projects from JetBrains IDEs to search.
 
 Supports:
 
-- IDEA Ultimate (Toolbox, Snap, Flatpack)
-- IDEA Community Edition (Toolbox, Snap, Arch Linux Package)
-- Webstorm (Toolbox, Snap)
 - CLion (Toolbox, Snap)
 - GoLand (Toolbox)
-- PyCharm (Toolbox)
+- IDEA Community Edition (Toolbox, Snap, Arch Linux Package)
+- IDEA Ultimate (Toolbox, Snap, Flatpack)
 - PhpStorm (Toolbox, Snap)
+- PyCharm (Toolbox)
 - Rider (Toolbox)
+- Webstorm (Toolbox, Snap)
 
 ## Requirements
 

--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ A Gnome shell extension to add recent projects from JetBrains IDEs to search.
 
 Supports:
 
+- Android Studio (Toolbox)
 - CLion (Toolbox, Snap)
 - GoLand (Toolbox)
 - IDEA Community Edition (Toolbox, Snap, Arch Linux Package)

--- a/extension.ts
+++ b/extension.ts
@@ -153,6 +153,13 @@ const PRODUCTS: Map<string, ProductInfo> = new Map<string, ProductInfo>(
         "jetbrains-rider.desktop",
       ],
     },
+    {
+      key: "android-studio",
+      desktopNames: [
+        // Toolbox installation
+        "jetbrains-studio.desktop",
+      ],
+    },
   ].map((product) => [product.key, product])
 );
 

--- a/find-projects.py
+++ b/find-projects.py
@@ -26,26 +26,27 @@ from pathlib import Path
 from traceback import format_exc
 
 
-ProductInfo = namedtuple('ProductInfo', 'key config_glob')
+ProductInfo = namedtuple('ProductInfo', 'key config_glob base_dir')
 
 
 PRODUCTS = [
-    ProductInfo(key='idea', config_glob='IntelliJIdea*'),
-    ProductInfo(key='idea-ce', config_glob='IdeaIC*'),
-    ProductInfo(key='webstorm', config_glob='WebStorm*'),
-    ProductInfo(key='clion', config_glob='CLion*'),
-    ProductInfo(key='goland', config_glob='GoLand*'),
-    ProductInfo(key='pycharm', config_glob='PyCharm*'),
-    ProductInfo(key='phpstorm', config_glob='PhpStorm*'),
-    ProductInfo(key='rider', config_glob='Rider*'),
+    ProductInfo(key='idea', config_glob='IntelliJIdea*', base_dir="JetBrains"),
+    ProductInfo(key='idea-ce', config_glob='IdeaIC*', base_dir="JetBrains"),
+    ProductInfo(key='webstorm', config_glob='WebStorm*', base_dir="JetBrains"),
+    ProductInfo(key='clion', config_glob='CLion*', base_dir="JetBrains"),
+    ProductInfo(key='goland', config_glob='GoLand*', base_dir="JetBrains"),
+    ProductInfo(key='pycharm', config_glob='PyCharm*', base_dir="JetBrains"),
+    ProductInfo(key='phpstorm', config_glob='PhpStorm*', base_dir="JetBrains"),
+    ProductInfo(key='rider', config_glob='Rider*', base_dir="JetBrains"),
+    ProductInfo(key='android-studio', config_glob='AndroidStudio*', base_dir="Google"),
 ]
 
 
 def product_version(config_dir):
-    version = re.search(r'\d{4}\.\d{1,2}', config_dir.name)
+    version = re.search(r'\d{1,4}\.\d{1,2}', config_dir.name)
     if version:
-        year, revision = version.group(0).split('.')
-        return (int(year), int(revision))
+        epoch, major = version.group(0).split('.')
+        return (int(epoch), int(major))
     else:
         raise ValueError(f'Not a valid IDEA config directory: {config_dir}')
 
@@ -59,7 +60,7 @@ def find_config_directories(product: ProductInfo):
         config_home = Path(config_home)
     else:
         config_home = Path.home() / '.config'
-    yield from (config_home / 'JetBrains').glob(product.config_glob)
+    yield from (config_home / product.base_dir).glob(product.config_glob)
 
 
 def find_latest_recent_projects_file(product: ProductInfo):


### PR DESCRIPTION
This add supports for Android Studio installed from the toolbox.

Due to the files being stored under (for example)  `~/.config/Google/AndroidStudio4.1/` a few modifications were needed:
 * `ProductInfo` is expanded to contain the base directory (`Google` or `JetBrains`)
 * the directory matching was relaxed to allow 1-4 numbers instead of requiring 4 so that `IntelliJIdea2020.3` and `AndroidStudio4.1` may also match.

The list of supported products in the README.md is also sorted alphabetically now.